### PR TITLE
ipfs migration to boxo

### DIFF
--- a/file/unixfile.go
+++ b/file/unixfile.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	ft "github.com/bittorrent/go-unixfs"
 	uio "github.com/bittorrent/go-unixfs/io"
 	"github.com/bittorrent/go-unixfs/util"
@@ -13,8 +14,8 @@ import (
 	files "github.com/bittorrent/go-btfs-files"
 	cid "github.com/ipfs/go-cid"
 
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 	ipld "github.com/ipfs/go-ipld-format"
-	dag "github.com/ipfs/go-merkledag"
 )
 
 // Number to file to prefetch in directories

--- a/hamt/hamt.go
+++ b/hamt/hamt.go
@@ -33,10 +33,10 @@ import (
 	format "github.com/bittorrent/go-unixfs"
 	"github.com/bittorrent/go-unixfs/internal"
 
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 	bitfield "github.com/ipfs/go-bitfield"
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
-	dag "github.com/ipfs/go-merkledag"
 )
 
 const (

--- a/importer/balanced/builder.go
+++ b/importer/balanced/builder.go
@@ -54,12 +54,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	ft "github.com/bittorrent/go-unixfs"
 	h "github.com/bittorrent/go-unixfs/importer/helpers"
 	pb "github.com/bittorrent/go-unixfs/pb"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
-	dag "github.com/ipfs/go-merkledag"
 )
 
 // Layout builds a balanced DAG layout. In a balanced DAG of depth 1, leaf nodes

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"sync"
 
-	dag "github.com/ipfs/go-merkledag"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 
 	ft "github.com/bittorrent/go-unixfs"
 	pb "github.com/bittorrent/go-unixfs/pb"

--- a/importer/trickle/trickledag.go
+++ b/importer/trickle/trickledag.go
@@ -19,12 +19,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	ft "github.com/bittorrent/go-unixfs"
 	h "github.com/bittorrent/go-unixfs/importer/helpers"
 	pb "github.com/bittorrent/go-unixfs/pb"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
-	dag "github.com/ipfs/go-merkledag"
 )
 
 // depthRepeat specifies how many times to append a child tree of a

--- a/io/dagreader.go
+++ b/io/dagreader.go
@@ -7,8 +7,8 @@ import (
 	"io"
 
 	"github.com/bittorrent/go-unixfs"
+	mdag "github.com/ipfs/boxo/ipld/merkledag"
 	ipld "github.com/ipfs/go-ipld-format"
-	mdag "github.com/ipfs/go-merkledag"
 )
 
 // Common errors

--- a/io/directory.go
+++ b/io/directory.go
@@ -10,7 +10,7 @@ import (
 	"github.com/alecthomas/units"
 	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
-	mdag "github.com/ipfs/go-merkledag"
+	mdag "github.com/ipfs/boxo/ipld/merkledag"
 
 	format "github.com/bittorrent/go-unixfs"
 	hamt "github.com/bittorrent/go-unixfs/hamt"

--- a/io/resolve.go
+++ b/io/resolve.go
@@ -5,7 +5,7 @@ import (
 
 	ft "github.com/bittorrent/go-unixfs"
 	hamt "github.com/bittorrent/go-unixfs/hamt"
-	dag "github.com/ipfs/go-merkledag"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 
 	ipld "github.com/ipfs/go-ipld-format"
 )

--- a/mod/dagmodifier.go
+++ b/mod/dagmodifier.go
@@ -18,9 +18,9 @@ import (
 	util "github.com/bittorrent/go-unixfs/util"
 
 	chunker "github.com/bittorrent/go-btfs-chunker"
+	mdag "github.com/ipfs/boxo/ipld/merkledag"
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
-	mdag "github.com/ipfs/go-merkledag"
 )
 
 // Common errors
@@ -669,11 +669,17 @@ func (mdm *MetaDagModifier) GetDb() *help.DagBuilderHelper {
 //
 // There are three scenarios possible:
 // Scenario #1. No existing metadata for the `root`. So this scenario is
-//    to create a new metadata sub-DAG.
+//
+//	to create a new metadata sub-DAG.
+//
 // Scenario #2. There are existing keys for the given `metadata` items.
-//    Then this is to update the metadata sub-DAG with the given items.
+//
+//	Then this is to update the metadata sub-DAG with the given items.
+//
 // Scenario #3. There are no pre-existing metadata items for the given `metadata` items.
-//    Then this scenario is to append given items to the metadata sub-DAG.
+//
+//	Then this scenario is to append given items to the metadata sub-DAG.
+//
 // TODO: trickle format
 // Preconditions include that first the given `metadata` is in compact JSON format.
 // Note that the given `metadata` should be added to the first element of the metadata list.

--- a/unixfs.go
+++ b/unixfs.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-	dag "github.com/ipfs/go-merkledag"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 
 	pb "github.com/bittorrent/go-unixfs/pb"
 	ipld "github.com/ipfs/go-ipld-format"

--- a/util/metautils.go
+++ b/util/metautils.go
@@ -9,7 +9,7 @@ import (
 	uio "github.com/bittorrent/go-unixfs/io"
 
 	ipld "github.com/ipfs/go-ipld-format"
-	mdag "github.com/ipfs/go-merkledag"
+	mdag "github.com/ipfs/boxo/ipld/merkledag"
 )
 
 // checkAndSplitMetadata returns both data root node and metadata root node if exists from


### PR DESCRIPTION
As part of the IPFS SDK dependencies migration to boxo, this update is necessary to move to boxo SDK for BTFS. I'll be doing other Pull Request in several BTFS repos to safely move to boxo and support newer golang releases